### PR TITLE
Update and move PHP open_basedir variable

### DIFF
--- a/zoneminder/httpd-zoneminder.conf
+++ b/zoneminder/httpd-zoneminder.conf
@@ -1,4 +1,4 @@
-# /etc/httpd/conf/extra/httpd-zm.conf
+# /etc/httpd/conf/extra/httpd-zoneminder.conf
 # Config for zoneminder web app
 
 Alias /zm "/srv/http/zoneminder"
@@ -18,3 +18,6 @@ ScriptAlias /cgi-bin "/srv/http/cgi-bin"
   Order allow,deny
   Allow from all
 </Directory>
+
+# Provide PHP access to important directories
+php_admin_value open_basedir "/srv/http/:/home/:/tmp/:/usr/share/pear/:/usr/share/webapps/:/etc/zm.conf:/srv/http/zoneminder/:/var/cache/zoneminder/:/srv/zoneminder/socks/:/var/log/zoneminder/"

--- a/zoneminder/php.ini.sed
+++ b/zoneminder/php.ini.sed
@@ -7,6 +7,3 @@
 \|^;extension=openssl.so$|   s|^;||;
 \|^;extension=ftp.so$|       s|^;||;
 \|^;extension=zip.so$|       s|^;||;
-
-# Add zoneminder paths to open_basedir
-s|^open_basedir = /srv/http/:/home/:/tmp/:/usr/share/pear/:/usr/share/webapps/$|&:/etc:/srv/http/zoneminder/:/var/cache/zoneminder/:/srv/zoneminder/socks:/var/log/zoneminder|;

--- a/zoneminder/zoneminder.install
+++ b/zoneminder/zoneminder.install
@@ -2,17 +2,14 @@ post_install() {
     # edit /etc/php.ini for Zoneminder
     sed -e '
     # Enable these libraries by removing the leading comment character
-    \|^;extension=pdo_mysql.so$| s|^;||;
+    \|^;extension=ftp.so$|       s|^;||;
     \|^;extension=gd.so$|        s|^;||;
     \|^;extension=gettext.so$|   s|^;||;
     \|^;extension=mcrypt.so$|    s|^;||;
-    \|^;extension=sockets.so$|   s|^;||;
     \|^;extension=openssl.so$|   s|^;||;
-    \|^;extension=ftp.so$|       s|^;||;
+    \|^;extension=pdo_mysql.so$| s|^;||;
+    \|^;extension=sockets.so$|   s|^;||;
     \|^;extension=zip.so$|       s|^;||;
-    
-    # Add zoneminder paths to open_basedir
-    s|^open_basedir = /srv/http/:/home/:/tmp/:/usr/share/pear/:/usr/share/webapps/$|&:/etc:/srv/http/zoneminder/:/var/cache/zoneminder/:/srv/zoneminder/socks:/var/log/zoneminder|;
     ' /etc/php/php.ini > /etc/php/php.ini.zoneminder
 
     # edit /etc/httpd/conf/httpd.conf for Zoneminder
@@ -51,19 +48,17 @@ post_install() {
 
   PHP configuration
   -----------------
-  * Uncomment the pdo_mysql.so line in /etc/php/php.ini to enable MariaDB:
-    extension=mysql.so
-  * Check and make sure these are uncommented:
+  * Check and make sure these are uncommented in /etc/php/php.ini:
+    extension=ftp.so
     extension=gd.so
     extension=gettext.so
     extension=mcrypt.so
-    extension=mysqli.so
-    extension=sockets.so
-    extension=openssl.so
-    extension=ftp.so
+	extension=openssl.so
+	extension=pdo_mysql.so
+	extension=sockets.so
     extension=zip.so
-  * Add to /etc, /srv/http/zoneminder, /var/cache/zoneminder, and /srv/zoneminder/socks to open_basedir:
-    open_basedir = /home:/tmp:/usr/share/pear:/etc:/srv/http/zoneminder/:/var/cache/zoneminder/:/srv/zoneminder/socks
+  * Add /etc/zm.conf, /srv/http/zoneminder, /var/cache/zoneminder, and /srv/zoneminder/socks to open_basedir in the zoneminder vhosts configuration file in apache:
+    php_admin_value open_basedir "/srv/http/:/home/:/tmp/:/usr/share/pear/:/usr/share/webapps/:/etc/zm.conf:/srv/http/zoneminder/:/var/cache/zoneminder/:/srv/zoneminder/socks/:/var/log/zoneminder/"
   * Set your timezone in php.ini:
     date.timezone = <your_country>/<your_city>
 
@@ -116,18 +111,17 @@ Note:
 
 ==> Disable php with mysql if it isn't needed with others servers, 
 ==> comment that lines in /etc/php/php.ini:
-==> "extension=mysql.so"
+==> "extension=ftp.so"
 ==> "extension=gd.so"
 ==> "extension=gettext.so"
 ==> "extension=mcrypt.so"
-==> "extension=mysqli.so"
+==> "extension=openssl.so"
+==> "extension=pdo_mysql.so"
 ==> "extension=sockets.so"
+==> "extension=zip.so"
 ==> "date.timezone = <my_country>/<my_city>"
 
-==> Edit /etc/php/php.ini and remove "/etc" and "/srv/http/zoneminder"
-==> in the "open_basedir".
-
-==> Remove log files and "zonemider" directory in "/var/log/zoneminder".
+==> Remove log files and "zoneminder" directory in "/var/log/zoneminder".
 
 ==> Backup and remove "events", "images" and "temp" dirs in "/var/cache/zoneminder".
 EOF


### PR DESCRIPTION
To improve security, the vhost configuration for zoneminder should set the
open_basedir PHP variable. This ensures other vhosts cannot access zoneminder
files. The entire /etc/ tree was accessible to apache/php. Some minor typos
were also fixed.
- Moved the open_basedir variable configuration for zoneminder directly to
  /etc/httpd/conf/extra/httpd-zoneminder.conf.
- Changed /etc/ to /etc/zm.conf so the rest of /etc/ is not accessible.
- Cleaned up zoneminder.install to reflect recent changes.
