### PR TITLE
Remove short_open_tag from httpd-zoneminder.conf

### DIFF
--- a/zoneminder-git/httpd-zoneminder.conf
+++ b/zoneminder-git/httpd-zoneminder.conf
@@ -7,8 +7,6 @@ Alias /zm "/srv/http/zoneminder"
   AllowOverride None
   Order allow,deny
   Allow from all
-  # The code unfortunately uses short tags in many places
-  php_value short_open_tag On
 </Directory>
 
 ScriptAlias /cgi-bin "/srv/http/cgi-bin"

--- a/zoneminder/httpd-zoneminder.conf
+++ b/zoneminder/httpd-zoneminder.conf
@@ -7,8 +7,6 @@ Alias /zm "/srv/http/zoneminder"
   AllowOverride None
   Order allow,deny
   Allow from all
-  # The code unfortunately uses short tags in many places
-  php_value short_open_tag On
 </Directory>
 
 ScriptAlias /cgi-bin "/srv/http/cgi-bin"


### PR DESCRIPTION
The short_open_tag is not needed. Zoneminder only uses <?= tags which work
with or without short_open_tags turned on. This is a minor preventative
security fix.
